### PR TITLE
Remove unused vanity redirects.

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,6 +1,2 @@
 # Redirect default Netlify subdomain to primary domain
 https://sharp-mcnulty-e3cc33.netlify.com/* https://www.samshadwell.com/:splat 301!
-
-# Redirect vanity urls to relevant favorites fragment
-/albums /favorite-things#albums
-/books  /favorite-things#books


### PR DESCRIPTION
Removes the unused vanity redirects `/albums` and `/books`

These weren't used anywhere, just trimming some complexity here.